### PR TITLE
remove react-paginate and change to select pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24724,17 +24724,6 @@
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-paginate": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.1.4.tgz",
-      "integrity": "sha512-c3rxjcTEqeDQa6LqXifxLeFguY2qy2CHGRphVjHLFFMGfIHyaJ+v3bOvIlLYEeohwQ1q+cQpknjsqBVrkc/SNA==",
-      "dependencies": {
-        "prop-types": "^15"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18"
-      }
-    },
     "node_modules/react-redux": {
       "version": "7.2.9",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
@@ -31390,7 +31379,7 @@
     },
     "packages/eslint-config": {
       "name": "@bsafer-system/eslint-config",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@rocketseat/eslint-config": "^1.1.3"
@@ -31401,7 +31390,7 @@
     },
     "packages/react": {
       "name": "@bsafer-system/react",
-      "version": "1.15.0",
+      "version": "1.15.3",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.2",
@@ -31416,7 +31405,6 @@
         "react-dropzone": "^14.2.2",
         "react-hook-form": "^7.41.3",
         "react-number-format": "^5.1.3",
-        "react-paginate": "8.1.4",
         "react-select": "^5.7.0",
         "tailwind-merge": "^1.12.0",
         "windstitch": "^0.3.0"
@@ -31482,7 +31470,7 @@
     },
     "packages/resolvers": {
       "name": "@bsafer-system/resolvers",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@bsafer-system/tokens": "*"
@@ -31499,7 +31487,7 @@
     },
     "packages/tokens": {
       "name": "@bsafer-system/tokens",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
         "@bsafer-system/eslint-config": "*",
@@ -31510,7 +31498,7 @@
     },
     "packages/ts-config": {
       "name": "@bsafer-system/ts-config",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT"
     }
   },
@@ -33200,7 +33188,6 @@
         "react-dropzone": "^14.2.2",
         "react-hook-form": "^7.41.3",
         "react-number-format": "^5.1.3",
-        "react-paginate": "8.1.4",
         "react-select": "^5.7.0",
         "react-test-renderer": "^18.2.0",
         "tailwind-merge": "^1.9.1",
@@ -50477,14 +50464,6 @@
       "integrity": "sha512-QV7QHzHrk9ZS9V0bWkIwu6ywiXJt0www4/cXWEVEgwaNqthmOZl/Cf5O0ukEPlGZJJr06Jh3+CM4rZsvXn8cOg==",
       "requires": {
         "prop-types": "^15.7.2"
-      }
-    },
-    "react-paginate": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.1.4.tgz",
-      "integrity": "sha512-c3rxjcTEqeDQa6LqXifxLeFguY2qy2CHGRphVjHLFFMGfIHyaJ+v3bOvIlLYEeohwQ1q+cQpknjsqBVrkc/SNA==",
-      "requires": {
-        "prop-types": "^15"
       }
     },
     "react-redux": {

--- a/packages/docs/src/stories/Pagination.stories.tsx
+++ b/packages/docs/src/stories/Pagination.stories.tsx
@@ -67,8 +67,10 @@ export const Playground: StoryFn<PaginationProps<IOptions>> = (props) => {
             </tbody>
           </table>
         </div>
+
         <Pagination
           perPageOptions={props.perPageOptions}
+          initSelectAsFrom={props.initSelectAsFrom}
           items={options}
           onPageChange={({ filteredItems }: { filteredItems: IOptions[] }) => {
             setItemsFiltrados(filteredItems)
@@ -80,6 +82,9 @@ export const Playground: StoryFn<PaginationProps<IOptions>> = (props) => {
 }
 
 Playground.argTypes = {
+  initSelectAsFrom: {
+    name: 'initSelectAsFrom: A number to trigger buttons or select component'
+  },
   perPageOptions: {
     // control: 'select',
     // options: ['2', '8', '25'],
@@ -88,5 +93,6 @@ Playground.argTypes = {
 }
 
 Playground.args = {
+  initSelectAsFrom: 5,
   perPageOptions: ['3', '7', '10']
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,8 +35,7 @@
     "react-number-format": "^5.1.3",
     "react-select": "^5.7.0",
     "windstitch": "^0.3.0",
-    "tailwind-merge": "^1.12.0",
-    "react-paginate": "8.1.4"
+    "tailwind-merge": "^1.12.0"
   },
   "devDependencies": {
     "@bsafer-system/eslint-config": "*",

--- a/packages/react/src/organisms/Pagination/index.tsx
+++ b/packages/react/src/organisms/Pagination/index.tsx
@@ -1,7 +1,8 @@
+import { ArrowLeft2, ArrowRight2 } from 'iconsax-react'
+import { useEffect, useMemo, useState } from 'react'
 import { Select } from '../../core/Select'
 import { Text } from '../../core/Text'
-import { useEffect, useMemo, useState } from 'react'
-import ReactPaginate from 'react-paginate'
+import { PaginationButton } from './styles'
 
 interface IOnPageChangeData<T> {
   currentPage: number
@@ -35,6 +36,12 @@ export interface PaginationProps<T> {
    * @default ['10', '15', '25', '50']
    */
   perPageOptions?: string[]
+
+  /**
+   * Number of buttons available before render a select
+   * @default 5
+   */
+  initSelectAsFrom?: number
 }
 
 const defaultPerPageOptions: IPerPageOptions[] = [
@@ -49,7 +56,8 @@ type PaginationComponent = <T>(props: PaginationProps<T>) => JSX.Element
 export const Pagination: PaginationComponent = ({
   onPageChange,
   items,
-  perPageOptions
+  perPageOptions,
+  initSelectAsFrom = 5
 }) => {
   const formattedPerPageOptions: IPerPageOptions[] = useMemo(() => {
     let newPerPageOptionsArray: IPerPageOptions[] = []
@@ -73,6 +81,7 @@ export const Pagination: PaginationComponent = ({
 
   const pageCount = Math.ceil(totalRecords / Number(perPage.value))
   const amountPerPage = currentPage * Number(perPage.value)
+  const arrayFromPageCount = Array.from(Array(pageCount).keys())
 
   const indexPerPage = useMemo(
     () => ({
@@ -130,19 +139,58 @@ export const Pagination: PaginationComponent = ({
         </div>
       </div>
       <div className="flex items-center gap-2 [&_*]:select-none">
+        {pageCount > initSelectAsFrom && (
+          <PaginationButton
+            onClick={() => {
+              if (currentPage > 0) handlePageChange(currentPage - 1)
+            }}
+            disabled={currentPage <= 0}
+          >
+            <ArrowLeft2 />
+          </PaginationButton>
+        )}
+
         <Text>Página</Text>
-        <ReactPaginate
-          pageCount={pageCount}
-          pageRangeDisplayed={3}
-          forcePage={currentPage}
-          onPageChange={({ selected }) => handlePageChange(selected)}
-          containerClassName="flex justify-baseline gap-2"
-          pageLinkClassName="block py-1 px-2 text-grey-500 hover:bg-grey-100 rounded-2xl min-w-[1.5rem] text-center font-regular"
-          nextClassName="hidden"
-          previousClassName="hidden"
-          activeClassName="[&_a]:text-black"
-          breakLinkClassName="block h-full text-black pt-1"
-        />
+
+        {pageCount > initSelectAsFrom && (
+          <>
+            <Select
+              className="min-w-[4.2rem]"
+              options={arrayFromPageCount.map((i) => ({
+                label: `${i + 1}`,
+                value: `${i}`
+              }))}
+              value={{ label: `${currentPage + 1}`, value: `${currentPage}` }}
+              onValueChange={({ value }) => handlePageChange(Number(value))}
+              padding="0 0.2rem"
+            />
+            <Text className="whitespace-nowrap">de {pageCount}</Text>
+          </>
+        )}
+
+        {pageCount <= initSelectAsFrom &&
+          arrayFromPageCount.map((i) => {
+            return (
+              <PaginationButton
+                key={i}
+                onClick={() => handlePageChange(i)}
+                isCurrent={i === currentPage}
+              >
+                {i + 1}
+              </PaginationButton>
+            )
+          })}
+
+        {pageCount > initSelectAsFrom && (
+          <PaginationButton
+            onClick={() => {
+              if (currentPage < pageCount - 1) handlePageChange(currentPage + 1)
+            }}
+            disabled={currentPage >= pageCount - 1}
+          >
+            <ArrowRight2 />
+          </PaginationButton>
+        )}
       </div>
     </div>
   )

--- a/packages/react/src/organisms/Pagination/index.tsx
+++ b/packages/react/src/organisms/Pagination/index.tsx
@@ -146,7 +146,7 @@ export const Pagination: PaginationComponent = ({
             }}
             disabled={currentPage <= 0}
           >
-            <ArrowLeft2 />
+            <ArrowLeft2 size={18} />
           </PaginationButton>
         )}
 
@@ -188,7 +188,7 @@ export const Pagination: PaginationComponent = ({
             }}
             disabled={currentPage >= pageCount - 1}
           >
-            <ArrowRight2 />
+            <ArrowRight2 size={18} />
           </PaginationButton>
         )}
       </div>

--- a/packages/react/src/organisms/Pagination/styles.ts
+++ b/packages/react/src/organisms/Pagination/styles.ts
@@ -1,0 +1,16 @@
+import { w } from 'windstitch'
+
+export const PaginationButton = w.button(
+  `
+    py-1 px-2 bg-transparent border-0 hover:bg-grey-100  font-regular rounded-full disabled:hover:bg-transparent disabled:text-grey-200
+  `,
+  {
+    defaultVariants: {
+      isCurrent: false
+    },
+    variants: {
+      isCurrent: (isCurrent: boolean) =>
+        isCurrent ? 'text-black' : 'text-grey-500'
+    }
+  }
+)


### PR DESCRIPTION
- Correção do Pagination:
  - Remoção do pacote `react-paginate`
  - Adição do `Select` a partir de um número estabelecido na propriedade `initSelectAsFrom`

![2023-07-05_11-35](https://github.com/bsafer-organization/system/assets/19709577/4bb29d79-5f11-4401-b1f8-600c3e8a5f1f)
![2023-07-05_11-36](https://github.com/bsafer-organization/system/assets/19709577/90d40128-ae53-45c9-9d9e-a43c18bfa923)
